### PR TITLE
Add Elasticsearch version string to manifest file

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,8 @@
     :omit-source   true
     :javac-options ["-target" "1.8", "-source" "1.8"]
     :target-path   "target/%s"
-    :uberjar-name  "elasticsearch.metabase-driver.jar"}
+    :uberjar-name  "elasticsearch.metabase-driver.jar"
+    :manifest      {"X-Compile-Elasticsearch-Version" "7.10.1"}}
 
    :unit_tests
    {:test-paths     ^:replace ["test_unit"]}})


### PR DESCRIPTION
Per https://discourse.metabase.com/t/elasticsearch-driver/12770/3

This adds a manifest option to the `project.clj` file so that it gets bundled with the jar file and the Elasticsearch driver can read it.